### PR TITLE
Feat: Adding Primary Key and Tests to Two Globepay Stage Models

### DIFF
--- a/deel_transactions/models/data_mart/fact_globepay__transactions.yml
+++ b/deel_transactions/models/data_mart/fact_globepay__transactions.yml
@@ -56,7 +56,7 @@ models:
           - not_null
           - accepted_values:
               values: [ACCEPTED, DECLINED]
-        description: "The stage of the transaction"
+        description: "The state of the transaction"
 
       - name: cvv_provided
         data_type: boolean

--- a/deel_transactions/models/stage/stage_globepay__acceptance_reports.sql
+++ b/deel_transactions/models/stage/stage_globepay__acceptance_reports.sql
@@ -1,20 +1,32 @@
-select 
-    external_ref
-    , status
-    , source
-    , ref
-    , date_time
-    , state
-    , cvv_provided
-    , amount
-    , country
-    , currency
-    , rates
-    , CASE WHEN currency = 'CAD' THEN CAST(JSON_EXTRACT_SCALAR(rates, '$.CAD') as float64)
-      WHEN currency = 'MXN' THEN CAST(JSON_EXTRACT_SCALAR(rates, '$.MXN') as float64)
-      WHEN currency = 'EUR' THEN CAST(JSON_EXTRACT_SCALAR(rates, '$.EUR') as float64)
-      WHEN currency = 'USD' THEN CAST(JSON_EXTRACT_SCALAR(rates, '$.USD') as float64)
-      WHEN currency = 'AUD' THEN CAST(JSON_EXTRACT_SCALAR(rates, '$.AUD') as float64)
-      WHEN currency = 'GBP' THEN CAST(JSON_EXTRACT_SCALAR(rates, '$.GBP') as float64)
-      end as exchange_rate
-from {{ source('transactions', 'globepay_acceptance_report') }}
+WITH
+  globepay_acceptance AS (
+  SELECT
+    external_ref,
+    status,
+    SOURCE,
+    ref,
+    date_time,
+    state,
+    cvv_provided,
+    amount,
+    country,
+    currency,
+    rates,
+    CASE
+      WHEN currency = 'CAD' THEN CAST(JSON_EXTRACT_SCALAR(rates, '$.CAD') AS float64)
+      WHEN currency = 'MXN' THEN CAST(JSON_EXTRACT_SCALAR(rates, '$.MXN') AS float64)
+      WHEN currency = 'EUR' THEN CAST(JSON_EXTRACT_SCALAR(rates, '$.EUR') AS float64)
+      WHEN currency = 'USD' THEN CAST(JSON_EXTRACT_SCALAR(rates, '$.USD') AS float64)
+      WHEN currency = 'AUD' THEN CAST(JSON_EXTRACT_SCALAR(rates, '$.AUD') AS float64)
+      WHEN currency = 'GBP' THEN CAST(JSON_EXTRACT_SCALAR(rates, '$.GBP') AS float64)
+  END
+    AS exchange_rate
+  FROM
+    {{ source('transactions', 'globepay_acceptance_report') }}
+)
+
+SELECT
+  {{ dbt_utils.generate_surrogate_key(['external_ref']) }} as PK_STAGE_GLOBEPAY__ACCEPTANCE_REPORTS,
+  *
+FROM
+  globepay_acceptance

--- a/deel_transactions/models/stage/stage_globepay__acceptance_reports.yml
+++ b/deel_transactions/models/stage/stage_globepay__acceptance_reports.yml
@@ -8,50 +8,83 @@ models:
       Granularity: Per transaction
 
     columns:
+      - name: pk_stage_globepay__acceptance_reports
+        data_type: string
+        tests:
+          - unique
+          - not_null
+        description: "The primary key of the table - based on external_ref"
+
       - name: external_ref
         data_type: string
-        description: ""
+        tests:
+          - not_null
+        description: "The external ref ID"
 
       - name: status
         data_type: boolean
-        description: ""
+        tests:
+          - not_null
+        description: "The status of the transaction"
 
       - name: source
         data_type: string
-        description: ""
+        tests:
+          - not_null
+        description: "The source of the transaction"
 
       - name: ref
         data_type: string
-        description: ""
+        tests:
+          - not_null
+        description: "The reference ID"
 
       - name: date_time
         data_type: timestamp
-        description: ""
+        tests:
+          - not_null
+        description: "The timestamp of the transaction"
 
       - name: state
         data_type: string
-        description: ""
+        tests:
+          - not_null
+          - accepted_values:
+              values: [ACCEPTED, DECLINED]
+        description: "The state of the transaction"
 
       - name: cvv_provided
         data_type: boolean
-        description: ""
+        tests:
+          - not_null
+        description: "Boolean value for if the cvv was provided"
 
       - name: amount
         data_type: float64
-        description: ""
+        tests:
+          - not_null
+        description: "The transaction amount"
 
       - name: country
         data_type: string
-        description: ""
+        tests:
+          - not_null
+        description: "The country name"
 
       - name: currency
         data_type: string
-        description: ""
+        tests:
+          - not_null
+        description: "The local currency code"
 
       - name: rates
         data_type: string
-        description: ""
+        tests:
+          - not_null
+        description: "The exchange rates of various currencies against the USD"
 
       - name: exchange_rate
         data_type: float64
-        description: ""
+        tests:
+          - not_null
+        description: "The exchange rate of the local currency against the USD"

--- a/deel_transactions/models/stage/stage_globepay__chargeback_reports.sql
+++ b/deel_transactions/models/stage/stage_globepay__chargeback_reports.sql
@@ -1,6 +1,16 @@
-select
-    external_ref
-    , status
-    , source
-    , chargeback
-from {{ source('transactions', 'globepay_chargeback_report') }}
+WITH
+  globepay_chargeback AS (
+  SELECT
+    external_ref,
+    status,
+    SOURCE,
+    chargeback
+  FROM
+    {{ source('transactions', 'globepay_chargeback_report') }}
+)
+
+SELECT
+  {{ dbt_utils.generate_surrogate_key(['external_ref']) }} as PK_STAGE_GLOBEPAY__CHARGEBACK_REPORTS,
+  *
+FROM
+  globepay_chargeback

--- a/deel_transactions/models/stage/stage_globepay__chargeback_reports.yml
+++ b/deel_transactions/models/stage/stage_globepay__chargeback_reports.yml
@@ -7,18 +7,33 @@ models:
 
       Granularity: Per external reference ID
     columns:
+      - name: pk_stage_globepay__chargeback_reports
+        data_type: string
+        tests:
+          - unique
+          - not_null
+        description: "The primary key of the table - based on external_ref"
+
       - name: external_ref
         data_type: string
-        description: ""
+        tests:
+          - not_null
+        description: "The external ref ID"
 
       - name: status
         data_type: boolean
-        description: ""
+        tests:
+          - not_null
+        description: "The status of the transaction"
 
       - name: source
         data_type: string
-        description: ""
+        tests:
+          - not_null
+        description: "The source of the transaction"
 
       - name: chargeback
         data_type: boolean
-        description: ""
+        tests:
+          - not_null
+        description: "The chargeback flag"


### PR DESCRIPTION
This PR includes the addition of primary key to the two globepay stage models and the addition of tests to the yml file. 
It also includes a minor edit to a description in the fact globepay table yml file.